### PR TITLE
add support for ignoring ENOENT

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,12 @@ module.exports = postcss.plugin('postcss-url-hash', function (options) {
       log(cssUrlString);
       log(cssUrlString.toString());
 
-      cssUrlString.value = resolveDataUrl(cssUrlString.value);
+      try {
+        cssUrlString.value = resolveDataUrl(cssUrlString.value);
+      } catch(e) {
+        if (options.silent) return;
+        throw e;
+      }
 
       log(cssUrlString.toString());
 

--- a/lib/CssUrlString.js
+++ b/lib/CssUrlString.js
@@ -19,7 +19,7 @@ var CSSUrlString = function (string) {
   this.value = string.slice(4, -1);
   this.quotes = this.value[0];
   if (this.quotes === '\'' || this.quotes === '"') {
-    this.value = string.slice(1, -1);
+    this.value = this.value.slice(1, -1);
   } else {
     this.quotes = '';
   }


### PR DESCRIPTION
postcss-url-hash now fails if resource is not found. It's rather inconvinient to work with vendor files that can possibly contain corrupted urls.
options.silent can be passed to postcss-url-hash config to ignore resources that are not found.
